### PR TITLE
chore: update version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then add this `api-kotlin` dependency to your `pom.xml` project!
 <dependency>    
     <groupId>com.github.RetroAchievements</groupId>    
     <artifactId>api-kotlin</artifactId>    
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
@@ -10,7 +10,10 @@ class GetConsoleID {
             val id: String,
 
             @SerializedName("Name")
-            val name: String
+            val name: String,
+
+            @SerializedName("IconURL")
+            val iconUrl: String
         )
     }
 }


### PR DESCRIPTION
Update version number to 1.0.1, in preparation to release support for IconURL being introduced to GetConsoleID