### PR TITLE
docs(GetConsoleID): update mock example to include newly introduced IconURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then add this `api-kotlin` dependency to your `pom.xml` project!
 <dependency>    
     <groupId>com.github.RetroAchievements</groupId>    
     <artifactId>api-kotlin</artifactId>    
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
@@ -10,7 +10,10 @@ class GetConsoleID {
             val id: String,
 
             @SerializedName("Name")
-            val name: String
+            val name: String,
+
+            @SerializedName("IconURL")
+            val iconUrl: String
         )
     }
 }

--- a/src/main/resources/mock/v1/system/GetConsoleIDs.json
+++ b/src/main/resources/mock/v1/system/GetConsoleIDs.json
@@ -1,3 +1,3 @@
 [
-  { "ID": 1, "Name": "Mega Drive" }
+  { "ID": 1, "Name": "Mega Drive", "IconURL": "https://static.retroachievements.org/assets/images/system/md.png" }
 ]


### PR DESCRIPTION
This pull request is to push new changes to the GetConsoleID mock response now including IconURL as an available value introduced in [RetroAchievements/RAWeb#2264](https://github.com/RetroAchievements/RAWeb/pull/2264)