### PR TITLE
chore: Fix values for GetUserProfile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserProfile.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserProfile.kt
@@ -41,7 +41,7 @@ class GetUserProfile {
         val id: Long,
 
         @SerializedName("UserWallActive")
-        val userWallActive: Int,
+        val userWallActive: Boolean,
 
         @SerializedName("Motto")
         val motto: String?,

--- a/src/main/resources/mock/v1/user/GetUserProfile.json
+++ b/src/main/resources/mock/v1/user/GetUserProfile.json
@@ -12,6 +12,6 @@
   "Permissions": 1,
   "Untracked": 0,
   "ID": 16446,
-  "UserWallActive": 1,
+  "UserWallActive": true,
   "Motto": "Join me on Twitch! GameSquadSquad for live RA"
 }


### PR DESCRIPTION
Fixes an issue where the value for UserWallActive is supposed to be a Boolean value, but was set as an Int causing parsing issues.
This issue was caused due an inconsistency between GetUserSummary and GetUserProfile, where RetroAchievements actually returns an Integer for UserWallActive when called through GetUserSummary, but a Boolean when called from GetUserProfile