### PR TITLE
chore: add support to existing leaderboard APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+
+.idea

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then add this `api-kotlin` dependency to your `pom.xml` project!
 <dependency>    
     <groupId>com.github.RetroAchievements</groupId>    
     <artifactId>api-kotlin</artifactId>    
-    <version>1.0.10</version>
+    <version>1.0.14</version>
 </dependency>
 ```
 
@@ -466,6 +466,82 @@ if (response is NetworkResponse.Success) {
 
 </details>
 
+<details>
+<summary>GetGameLeaderboards</summary>
+<br>
+
+> A call to this endpoint will retrieve a given game's list of leaderboards, targeted by the game's ID.
+
+**Available Parameters**
+
+| Name   | Type | Description                            | Example | Default |
+|:-------|:-----|:---------------------------------------|:--------|:--------|
+| gameId | Long | The target game ID.                    | 14402   |         |
+| offset | Int  | number of entries to skip              | 100     | 0       |
+| count  | Int  | number of entries to return (max: 500) | 50      | 100     |
+
+**Example**
+```kotlin
+val credentials = RetroCredentials("<username>", "<web api key>")
+val api: RetroInterface = RetroClient(credentials).api
+
+val response: NetworkResponse<GetGameLeaderboards.Response, ErrorResponse> = api.getGameLeaderboards(
+    gameId = 14402
+)
+
+if (response is NetworkResponse.Success) {
+    // handle the data
+    val gameLeaderboards: GetGameLeaderboards.Response = response.body
+
+} else if (response is NetworkResponse.Error) {
+    // if the server returns an error it be found here
+    val errorResponse: ErrorResponse? = response.body
+
+    // if the api (locally) had an internal error, it'll be found here
+    val internalError: Throwable? = response.error
+}
+```
+
+</details>
+
+<details>
+<summary>GetLeaderboardEntries</summary>
+<br>
+
+> A call to this endpoint will retrieve a given leaderboard's entries, targeted by its ID.
+
+**Available Parameters**
+
+| Name   | Type | Description                            | Example | Default |
+|:-------|:-----|:---------------------------------------|:--------|:--------|
+| gameId | Long | The target game ID.                    | 14402   |         |
+| offset | Int  | number of entries to skip              | 100     | 0       |
+| count  | Int  | number of entries to return (max: 500) | 50      | 100     |
+
+**Example**
+```kotlin
+val credentials = RetroCredentials("<username>", "<web api key>")
+val api: RetroInterface = RetroClient(credentials).api
+
+val response: NetworkResponse<GetLeaderboardEntries.Response, ErrorResponse> = api.getLeaderboardEntries(
+    gameId = 14402
+)
+
+if (response is NetworkResponse.Success) {
+    // handle the data
+    val leaderboardEntries: GetLeaderboardEntries.Response = response.body
+
+} else if (response is NetworkResponse.Error) {
+    // if the server returns an error it be found here
+    val errorResponse: ErrorResponse? = response.body
+
+    // if the api (locally) had an internal error, it'll be found here
+    val internalError: Throwable? = response.error
+}
+```
+
+</details>
+
 #### Tickets
 
 <details>
@@ -554,7 +630,7 @@ if (response is NetworkResponse.Success) {
 | shouldReturnTicketsList                   | Int  | Set to 1 if you want deep ticket metadata in the response's Tickets array. | 0       |
 | isGettingTicketsForUnofficialAchievements | Int  | Set to 5 if you want ticket data for unofficial achievements.              | 0       |
 | count                                     | Int  | Count, number of records to return (default: 10, max: 100).                | 0       |
-| offset                                    | Int  |  number of entries to skip (default: 0).                                                    | 0       |
+| offset                                    | Int  | number of entries to skip (default: 0).                                    | 0       |
 
 **Example**
 ```kotlin

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/kotlin/org/retroachivements/api/RetroInterface.kt
+++ b/src/main/kotlin/org/retroachivements/api/RetroInterface.kt
@@ -247,6 +247,28 @@ interface RetroInterface {
     ): NetworkResponse<GetGameRankAndScore.Response, ErrorResponse>
 
     /**
+     * A call to this endpoint will retrieve a given game's list of leaderboards, targeted by the game's ID.
+     */
+    @Mock @MockResponse(body = "/v1/game/GetGameLeaderboards.json")
+    @POST("/API/API_GetGameLeaderboards.php")
+    suspend fun getGameLeaderboards(
+        @Query("i") gameId: Long,
+        @Query("o") offset: Int = 0,
+        @Query("c") count: Int = 100
+    ): NetworkResponse<GetGameLeaderboards.Response, ErrorResponse>
+
+    /**
+     * A call to this endpoint will retrieve a given leaderboard's entries, targeted by its ID.
+     */
+    @Mock @MockResponse(body = "/v1/game/GetLeaderboardEntries.json")
+    @POST("/API/API_GetLeaderboardEntries.php")
+    suspend fun getLeaderboardEntries(
+        @Query("i") gameId: Long,
+        @Query("o") offset: Int = 0,
+        @Query("c") count: Int = 100
+    ): NetworkResponse<GetLeaderboardEntries.Response, ErrorResponse>
+
+    /**
      * A call to this endpoint will retrieve the complete list of all system ID and name pairs on the site.
      *
      * [activeSystemsOnly] set to 1

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameLeaderboards.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameLeaderboards.kt
@@ -1,0 +1,38 @@
+package org.retroachivements.api.data.pojo.game
+
+import com.google.gson.annotations.SerializedName
+
+class GetGameLeaderboards {
+    data class Response(
+        @SerializedName("Count")
+        val count: Long,
+        @SerializedName("Total")
+        val total: Long,
+        @SerializedName("Results")
+        val results: List<Leaderboard>,
+    )
+
+    data class Leaderboard(
+        @SerializedName("ID")
+        val id: Long,
+        @SerializedName("RankAsc")
+        val rankAsc: Boolean,
+        @SerializedName("Title")
+        val title: String,
+        @SerializedName("Description")
+        val description: String,
+        @SerializedName("Format")
+        val format: String,
+        @SerializedName("TopEntry")
+        val topEntry: TopEntry,
+    )
+
+    data class TopEntry(
+        @SerializedName("User")
+        val user: String,
+        @SerializedName("Score")
+        val score: Long,
+        @SerializedName("FormattedScore")
+        val formattedScore: String,
+    )
+}

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetLeaderboardEntries.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetLeaderboardEntries.kt
@@ -1,0 +1,28 @@
+package org.retroachivements.api.data.pojo.game
+
+import com.google.gson.annotations.SerializedName
+
+class GetLeaderboardEntries {
+    data class Response(
+        @SerializedName("Count")
+        val count: Long,
+        @SerializedName("Total")
+        val total: Long,
+        @SerializedName("Results")
+        val results: List<Entry>,
+    )
+
+    data class Entry(
+        @SerializedName("User")
+        val user: String,
+        @SerializedName("DateSubmitted")
+        val dateSubmitted: String,
+        @SerializedName("Score")
+        val score: Long,
+        @SerializedName("FormattedScore")
+        val formattedScore: String,
+        @SerializedName("Rank")
+        val rank: Long,
+    )
+
+}

--- a/src/main/resources/mock/v1/game/GetGameLeaderboards.json
+++ b/src/main/resources/mock/v1/game/GetGameLeaderboards.json
@@ -1,0 +1,126 @@
+{
+    "Count": 10,
+    "Total": 64,
+    "Results": [
+        {
+            "ID": 19062,
+            "RankAsc": true,
+            "Title": "New Zealand One",
+            "Description": "Complete New Zealand S1 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 11903,
+                "FormattedScore": "1:59.03"
+            }
+        },
+        {
+            "ID": 19063,
+            "RankAsc": true,
+            "Title": "New Zealand Two",
+            "Description": "Complete New Zealand S2 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 15836,
+                "FormattedScore": "2:38.36"
+            }
+        },
+        {
+            "ID": 19064,
+            "RankAsc": true,
+            "Title": "New Zealand Three",
+            "Description": "Complete New Zealand S3 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 17619,
+                "FormattedScore": "2:56.19"
+            }
+        },
+        {
+            "ID": 19065,
+            "RankAsc": true,
+            "Title": "New Zealand Four",
+            "Description": "Complete New Zealand S4 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 14173,
+                "FormattedScore": "2:21.73"
+            }
+        },
+        {
+            "ID": 19066,
+            "RankAsc": true,
+            "Title": "New Zealand Five",
+            "Description": "Complete New Zealand S5 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 13963,
+                "FormattedScore": "2:19.63"
+            }
+        },
+        {
+            "ID": 19067,
+            "RankAsc": true,
+            "Title": "New Zealand Six",
+            "Description": "Complete New Zealand S6 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "JollyClubber",
+                "Score": 15422,
+                "FormattedScore": "2:34.22"
+            }
+        },
+        {
+            "ID": 19068,
+            "RankAsc": true,
+            "Title": "Greece One",
+            "Description": "Complete Greece S1 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 15252,
+                "FormattedScore": "2:32.52"
+            }
+        },
+        {
+            "ID": 19069,
+            "RankAsc": true,
+            "Title": "Greece Two",
+            "Description": "Complete Greece S2 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "josef733",
+                "Score": 13953,
+                "FormattedScore": "2:19.53"
+            }
+        },
+        {
+            "ID": 19070,
+            "RankAsc": true,
+            "Title": "Greece Three",
+            "Description": "Complete Greece S3 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "josef733",
+                "Score": 12140,
+                "FormattedScore": "2:01.40"
+            }
+        },
+        {
+            "ID": 19071,
+            "RankAsc": true,
+            "Title": "Greece Four",
+            "Description": "Complete Greece S4 in least time",
+            "Format": "MILLISECS",
+            "TopEntry": {
+                "User": "Thebpg13",
+                "Score": 15219,
+                "FormattedScore": "2:32.19"
+            }
+        }
+    ]
+}

--- a/src/main/resources/mock/v1/game/GetLeaderboardEntries.json
+++ b/src/main/resources/mock/v1/game/GetLeaderboardEntries.json
@@ -1,0 +1,76 @@
+{
+    "Count": 10,
+    "Total": 540,
+    "Results": [
+        {
+            "User": "Thebpg13",
+            "DateSubmitted": "2024-08-27T21:33:33+00:00",
+            "Score": 11903,
+            "FormattedScore": "1:59.03",
+            "Rank": 1
+        },
+        {
+            "User": "josef733",
+            "DateSubmitted": "2024-05-28T21:36:55+00:00",
+            "Score": 12656,
+            "FormattedScore": "2:06.56",
+            "Rank": 2
+        },
+        {
+            "User": "masakimu",
+            "DateSubmitted": "2023-10-26T20:43:26+00:00",
+            "Score": 12880,
+            "FormattedScore": "2:08.80",
+            "Rank": 3
+        },
+        {
+            "User": "Ryszard",
+            "DateSubmitted": "2023-10-01T17:01:14+00:00",
+            "Score": 13096,
+            "FormattedScore": "2:10.96",
+            "Rank": 4
+        },
+        {
+            "User": "PaulSavage",
+            "DateSubmitted": "2024-11-16T16:50:44+00:00",
+            "Score": 13263,
+            "FormattedScore": "2:12.63",
+            "Rank": 5
+        },
+        {
+            "User": "JollyClubber",
+            "DateSubmitted": "2024-11-22T11:38:58+00:00",
+            "Score": 13263,
+            "FormattedScore": "2:12.63",
+            "Rank": 5
+        },
+        {
+            "User": "EMDM15",
+            "DateSubmitted": "2023-08-13T10:38:39+00:00",
+            "Score": 13326,
+            "FormattedScore": "2:13.26",
+            "Rank": 7
+        },
+        {
+            "User": "xClawz",
+            "DateSubmitted": "2022-06-05T15:00:39+00:00",
+            "Score": 13350,
+            "FormattedScore": "2:13.50",
+            "Rank": 8
+        },
+        {
+            "User": "KboxGames",
+            "DateSubmitted": "2024-10-03T14:13:47+00:00",
+            "Score": 13360,
+            "FormattedScore": "2:13.60",
+            "Rank": 9
+        },
+        {
+            "User": "endresults",
+            "DateSubmitted": "2022-06-05T04:26:00+00:00",
+            "Score": 13376,
+            "FormattedScore": "2:13.76",
+            "Rank": 10
+        }
+    ]
+}

--- a/src/test/kotlin/org/retroachivements/api/RetroInterfaceTest.kt
+++ b/src/test/kotlin/org/retroachivements/api/RetroInterfaceTest.kt
@@ -431,6 +431,43 @@ class RetroInterfaceTest {
     }
 
     @Test
+    fun `check getGameLeaderboards response parser`() {
+
+        runBlocking {
+
+            // obtain mocked version of the API
+            val api = createMockedApi()
+
+            val gameLeaderboards: NetworkResponse<GetGameLeaderboards.Response, ErrorResponse> = api.getGameLeaderboards(
+                gameId = 14402
+            )
+
+            assert(gameLeaderboards is NetworkResponse.Success)
+
+            assertNotNull((gameLeaderboards as NetworkResponse.Success).body)
+        }
+    }
+
+    @Test
+    fun `check getLeaderboardEntries response parser`() {
+
+        runBlocking {
+
+            // obtain mocked version of the API
+            val api = createMockedApi()
+
+            val leaderboardEntries: NetworkResponse<GetLeaderboardEntries.Response, ErrorResponse> = api.getLeaderboardEntries(
+                gameId = 14402
+            )
+
+            assert(leaderboardEntries is NetworkResponse.Success)
+
+            assertNotNull((leaderboardEntries as NetworkResponse.Success).body)
+        }
+    }
+
+
+    @Test
     fun `check getConsoleIds response parser`() {
 
         runBlocking {


### PR DESCRIPTION
### Changes
- Adding support to these two endpoints
- - https://api-docs.retroachievements.org/v1/get-game-leaderboards.html
- - https://api-docs.retroachievements.org/v1/get-leaderboard-entries.html
- Fixing one table format
- Adding .idea folder to .gitignore