### PR TITLE
Fix: `getGameInfoAndUserProgress` fails due to type conflict

### DIFF
--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
@@ -48,7 +48,7 @@ class GetGameInfoAndUserProgress {
         val releasedAtGranularity: String?,
 
         @SerializedName("IsFinal")
-        val isFinal: Int,
+        val isFinal: Boolean,
 
         @SerializedName("RichPresencePatch")
         val richPresencePatch: String,

--- a/src/main/resources/mock/v1/game/GetGameInfoAndUserProgress.json
+++ b/src/main/resources/mock/v1/game/GetGameInfoAndUserProgress.json
@@ -12,7 +12,7 @@
   "Developer": "",
   "Genre": "",
   "Released": "June 23, 1991",
-  "IsFinal": 0,
+  "IsFinal": false,
   "RichPresencePatch": "cce60593880d25c97797446ed33eaffb",
   "players_total": 27080,
   "achievements_published": 23,


### PR DESCRIPTION
Hello 🙂 

I just figured out by fiddling around with this great api that the datatype of the `isFinal` field might have changed and the API now returns a `Boolean` instead of an `Int`.

After that my calls via `getGameInfoAndUserProgress` won't fail anymore with any serialization exception.

Cheers
