### PR TITLE
Fixed achievement type variable

### DIFF
--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
@@ -132,7 +132,7 @@ class GetGameInfoAndUserProgress {
             @SerializedName("MemAddr")
             val memAddr: String,
 
-            @SerializedName("Type")
+            @SerializedName("type")
             val type: String?,
 
             @SerializedName("DateEarnedHardcore")


### PR DESCRIPTION
The "type" variable of the GetGameInfoAndUserProgress class was cased incorrectly for the API, always returning null.