### PR TITLE
🚑️ Fixed GetGameExtended isFinal type

### DIFF
--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameExtended.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameExtended.kt
@@ -45,7 +45,7 @@ class GetGameExtended {
         val released: String?,
 
         @SerializedName("IsFinal")
-        val isFinal: Int,
+        val isFinal: Boolean,
 
         @SerializedName("RichPresencePatch")
         val richPresencePatch: String,

--- a/src/main/resources/mock/v1/game/GetGameExtended.json
+++ b/src/main/resources/mock/v1/game/GetGameExtended.json
@@ -12,7 +12,7 @@
   "Developer": "",
   "Genre": "",
   "Released": "June 23, 1991",
-  "IsFinal": 0,
+  "IsFinal": false,
   "RichPresencePatch": "cce60593880d25c97797446ed33eaffb",
   "players_total": 27080,
   "achievement_set_version_hash": "14ce9b51a2e1cf63d55b7ebf389de3c9f27c564b33f5b9a8e17836af2a61bfcd",


### PR DESCRIPTION
Fixes `Expected an int but was BOOLEAN at line 1 column 373 path $.IsFinal` error on `api.getGameExtended()`