### PR TITLE
Fix(parser): convert int into primitive boolean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.1.1</version>
+    <version>2.0.0</version>
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.retroachievements</groupId>
     <artifactId>api-kotlin</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/kotlin/org/retroachivements/api/core/BooleanJsonDeserializer.kt
+++ b/src/main/kotlin/org/retroachivements/api/core/BooleanJsonDeserializer.kt
@@ -1,0 +1,30 @@
+package org.retroachivements.api.core
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+import java.util.*
+
+/**
+ * This class takes care of converting integer booleans to primitive booleans,
+ * some values returned from RA can be represented as integers,
+ * if they migrate, it could introduce breaking changes.
+ */
+internal class BooleanJsonDeserializer : JsonDeserializer<Boolean> {
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Boolean {
+
+        val primitive = json.asJsonPrimitive
+        if (primitive.isBoolean) {
+            return primitive.asBoolean
+        }
+
+        if (primitive.isNumber) {
+            return primitive.asNumber.toInt() == 1
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/achievement/GetAchievementUnlocks.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/achievement/GetAchievementUnlocks.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.achievement
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetAchievementUnlocks {
 
@@ -38,8 +40,9 @@ class GetAchievementUnlocks {
                 @SerializedName("DateAwarded")
                 val dateAwarded: String,
 
+                @JsonAdapter(BooleanJsonDeserializer::class)
                 @SerializedName("HardcoreMode")
-                val hardcoreMode: Int,
+                val hardcoreMode: Boolean,
 
                 @SerializedName("RASoftcorePoints")
                 val raSoftcorePoints: Int

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/event/GetAchievementOfTheWeek.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/event/GetAchievementOfTheWeek.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.event
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetAchievementOfTheWeek {
 
@@ -92,8 +94,9 @@ class GetAchievementOfTheWeek {
             @SerializedName("DateAwarded")
             val dateAwarded: String,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("HardcoreMode")
-            val hardcoreMode: Int,
+            val hardcoreMode: Boolean,
 
             @SerializedName("RASoftcorePoints")
             val raSoftcorePoints: Int

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/feed/GetClaims.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/feed/GetClaims.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.feed
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetClaims {
 
@@ -54,8 +56,9 @@ class GetClaims {
             @SerializedName("MinutesLeft")
             val minutesLeft: Long,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("UserIsJrDev")
-            val userIsJrDev: Int
+            val userIsJrDev: Boolean
         )
     }
 }

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameExtended.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameExtended.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.game
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetGameExtended {
 
@@ -47,6 +49,7 @@ class GetGameExtended {
         @SerializedName("ReleasedAtGranularity")
         val releasedAtGranularity: String?,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("IsFinal")
         val isFinal: Boolean,
 

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameInfoAndUserProgress.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.game
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetGameInfoAndUserProgress {
 
@@ -47,6 +49,7 @@ class GetGameInfoAndUserProgress {
         @SerializedName("ReleasedAtGranularity")
         val releasedAtGranularity: String?,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("IsFinal")
         val isFinal: Boolean,
 

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameLeaderboards.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetGameLeaderboards.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.game
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetGameLeaderboards {
 
@@ -19,6 +21,7 @@ class GetGameLeaderboards {
         @SerializedName("ID")
         val id: Long,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("RankAsc")
         val rankAsc: Boolean,
 

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetUserGameLeaderboard.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/game/GetUserGameLeaderboard.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.game
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUserGameLeaderboard {
 
@@ -20,6 +22,7 @@ class GetUserGameLeaderboard {
             @SerializedName("ID")
             val id: Int,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("RankAsc")
             val rankAsc: Boolean,
 

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/system/GetConsoleID.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.system
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetConsoleID {
 
@@ -15,9 +17,11 @@ class GetConsoleID {
             @SerializedName("IconURL")
             val iconUrl: String,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("Active")
             val active: Boolean,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("IsGameSystem")
             val isGameSystem: Boolean
         )

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/ticket/GetMostRecentTickets.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/ticket/GetMostRecentTickets.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.ticket
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetMostRecentTickets {
 
@@ -60,8 +62,9 @@ class GetMostRecentTickets {
             @SerializedName("ReportState")
             val reportState: Int,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("Hardcore")
-            val hardcore: Int?,
+            val hardcore: Boolean?,
 
             @SerializedName("ReportNotes")
             val reportNotes: String,

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/ticket/GetTicketData.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/ticket/GetTicketData.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.ticket
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetTicketData {
 
@@ -50,8 +52,9 @@ class GetTicketData {
         @SerializedName("ReportState")
         val reportState: Int,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("Hardcore")
-        val hardcore: Int?,
+        val hardcore: Boolean?,
 
         @SerializedName("ReportNotes")
         val reportNotes: String,

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserCompletedGames.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserCompletedGames.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUserCompletedGames {
 
@@ -30,8 +32,9 @@ class GetUserCompletedGames {
             @SerializedName("PctWon")
             val pctWon: String,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("HardcoreMode")
-            val hardcoreMode: Long
+            val hardcoreMode: Boolean
         )
     }
 }

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserProfile.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserProfile.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUserProfile {
     data class Response(
@@ -37,12 +39,14 @@ class GetUserProfile {
         @SerializedName("Permissions")
         val permissions: Int,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("Untracked")
-        val untracked: Int,
+        val untracked: Boolean,
 
         @SerializedName("ID")
         val id: Long,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("UserWallActive")
         val userWallActive: Boolean,
 

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserRecentAchievements.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserRecentAchievements.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUserRecentAchievements {
 
@@ -9,8 +11,9 @@ class GetUserRecentAchievements {
             @SerializedName("Date")
             val date: String,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("HardcoreMode")
-            val hardcoreMode: Int,
+            val hardcoreMode: Boolean,
 
             @SerializedName("AchievementID")
             val achievementId: Long,

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserSummary.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUserSummary.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUserSummary {
 
@@ -56,8 +58,9 @@ class GetUserSummary {
         @SerializedName("ID")
         val id: Long,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("UserWallActive")
-        val userWallActive: Int,
+        val userWallActive: Boolean,
 
         @SerializedName("Motto")
         val motto: String?,
@@ -109,6 +112,7 @@ class GetUserSummary {
             @SerializedName("BadgeName")
             val badgeName: String,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("IsAwarded")
             val isAwarded: Boolean,
 
@@ -222,8 +226,9 @@ class GetUserSummary {
             @SerializedName("Released")
             val released: String?,
 
+            @JsonAdapter(BooleanJsonDeserializer::class)
             @SerializedName("IsFinal")
-            val isFinal: Int,
+            val isFinal: Boolean,
 
             @SerializedName("ConsoleName")
             val consoleName: String,

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUsersFollowingMe.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUsersFollowingMe.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUsersFollowingMe {
     data class Response(
@@ -24,6 +26,7 @@ class GetUsersFollowingMe {
         @SerializedName("PointsSoftcore")
         val pointsSoftcore: Long,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("AmIFollowing")
         val amIFollowing: Boolean,
     )

--- a/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUsersIFollow.kt
+++ b/src/main/kotlin/org/retroachivements/api/data/pojo/user/GetUsersIFollow.kt
@@ -1,6 +1,8 @@
 package org.retroachivements.api.data.pojo.user
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.retroachivements.api.core.BooleanJsonDeserializer
 
 class GetUsersIFollow {
     data class Response(
@@ -24,6 +26,7 @@ class GetUsersIFollow {
         @SerializedName("PointsSoftcore")
         val pointsSoftcore: Long,
 
+        @JsonAdapter(BooleanJsonDeserializer::class)
         @SerializedName("IsFollowingMe")
         val isFollowingMe: Boolean,
     )


### PR DESCRIPTION
This patch addresses issues with int booleans being transitioned into primitive booleans within RA's servers, resulting in expected integers not parsing.

Fields annotated with `@JsonAdapter(BooleanJsonDeserializer::class)` will now convert expected (or potential) int into primitive booleans, allowing compatibility with the server returning an int or a boolean without breaking the GSON parser.